### PR TITLE
Chore: Update menu header surcharge text to 2€

### DIFF
--- a/src/Pages/Menu.js
+++ b/src/Pages/Menu.js
@@ -159,7 +159,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Curryschotels (met rijst of frieten + 1.80€)</th>
+									<th> Curryschotels (met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -205,7 +205,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Tomatensaus (met rijst of frieten + 1.80€)</th>
+									<th> Tomatensaus (met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -246,7 +246,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Chop Shoy (met rijst of frieten + 1.80€)</th>
+									<th> Chop Shoy (met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -484,7 +484,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Zoetzure schotels(met rijst of frieten + 1.80€)</th>
+									<th> Zoetzure schotels(met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -534,7 +534,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Omelet(met rijst of frieten + 1.80€)</th>
+									<th> Omelet(met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -570,7 +570,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Specialiteiten(met rijst of frieten + 1.80€)</th>
+									<th> Specialiteiten(met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -739,7 +739,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Inktvis(met rijst of frieten + 1.80€)</th>
+									<th> Inktvis(met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -771,7 +771,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th> Gerechten in een potje(met rijst of frieten + 1.80€)</th>
+									<th> Gerechten in een potje(met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>
@@ -875,7 +875,7 @@ function Menu() {
 							<table>
 								<tr>
 									<td></td>
-									<th>Hoofdschotels (met rijst of frieten + 1.80€)</th>
+									<th>Hoofdschotels (met rijst of frieten + 2€)</th>
 								</tr>
 
 								<tr>


### PR DESCRIPTION
## Summary
- Update menu section headers to show +2€ surcharge instead of +1.80€
